### PR TITLE
Added additional dependencies for setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ android {
 dependencies {
     def hilt_version = "2.41"
     def room_version = "2.4.2"
+    def retrofit_version = "2.9.0"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_version"
@@ -75,7 +76,8 @@ dependencies {
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
 
     // Moshi
     implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
 
 dependencies {
     def hilt_version = "2.41"
+    def room_version = "2.4.2"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_version"
@@ -68,6 +69,10 @@ dependencies {
     // local unit tests
     testImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
     kaptTest "com.google.dagger:hilt-compiler:$hilt_version"
+
+    // Room
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     def hilt_version = "2.41"
     def room_version = "2.4.2"
     def retrofit_version = "2.9.0"
+    def moshi_version = "1.13.0"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_version"
@@ -80,7 +81,9 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
 
     // Moshi
-    implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
+    implementation "com.squareup.moshi:moshi:$moshi_version"
+    implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,12 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
+    // Retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+
+    // Moshi
+    implementation 'com.squareup.moshi:moshi-kotlin:1.13.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,8 @@ android {
 }
 
 dependencies {
+    def hilt_version = "2.41"
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
@@ -56,16 +58,16 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.4.0'
 
     // hilt
-    implementation 'com.google.dagger:hilt-android:2.41'
-    kapt 'com.google.dagger:hilt-compiler:2.41'
+    implementation "com.google.dagger:hilt-android:$hilt_version"
+    kapt "com.google.dagger:hilt-compiler:$hilt_version"
 
     // instrumentation tests
-    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.41'
-    kaptAndroidTest 'com.google.dagger:hilt-compiler:2.41'
+    androidTestImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
+    kaptAndroidTest "com.google.dagger:hilt-compiler:$hilt_version"
 
     // local unit tests
-    testImplementation 'com.google.dagger:hilt-android-testing:2.41'
-    kaptTest 'com.google.dagger:hilt-compiler:2.41'
+    testImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
+    kaptTest "com.google.dagger:hilt-compiler:$hilt_version"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.feature.fox.coffee_counter">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".BaseApplication"
         android:allowBackup="true"


### PR DESCRIPTION
## Description
I've added three new libraries and added internet-permission in the `AndroidManifest`. We need that permission to use retrofit.

* Room: Needed for saving data in a local database
* RetroFit: HTTP Client to communicate with the API
* Moshi: Note that normally you would use `gson` (a serialization/deserialization library), but there is a [good article](https://proandroiddev.com/goodbye-gson-hello-moshi-4e591116231e) that explains briefly why Moshi is the better alternative


## References
* [Room](https://developer.android.com/training/data-storage/room)
* [RetroFit](https://square.github.io/retrofit/)
* [Moshi](https://github.com/square/moshi)
* [Goodbye Gson, Hello Moshi](https://proandroiddev.com/goodbye-gson-hello-moshi-4e591116231e)
