### PR TITLE
Add schemas to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle files
 .gradle/
 build/
+schemas/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
## Description
I've added the schemas to the `.gitignore` since it always generated jsons that are probably not interesting for git.
Are there other folders that should be excluded?
