### PR TITLE
Fix typo at ApiService

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/ApiService.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/ApiService.kt
@@ -30,5 +30,5 @@ interface ApiService {
     suspend fun getItemById(@Path("id") id: String): Response<ItemResponse>
 
     @POST(USERS_ENDPOINT)
-    suspend fun signIn(@Body userBody: UserBody): Response<String>
+    suspend fun signUp(@Body userBody: UserBody): Response<String>
 }

--- a/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
+++ b/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
@@ -209,7 +209,7 @@ class ApiServiceTest {
     }
 
     @Test
-    fun `POST sign in`() = runBlocking {
+    fun `POST Users to SignUp`() = runBlocking {
 
         val body = UserBody("123456789", "foo", "123456789")
         val moshi = Moshi.Builder().build()
@@ -220,7 +220,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.signIn(body)
+        val actualResponse = apiService.signUp(body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(201)


### PR DESCRIPTION
- Fixed typo from #29
- Renamed `POST sign in` test method of `ApiServiceTest` to `POST Users to SignUp`
- Renamed `signIn` method of `ApiService` interface to `signUp`  and its call inside `POST Users to SignUp` at `ApiServiceTest` 