### PR TITLE
Add item repository

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/data/local/dao/ItemDao.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/local/dao/ItemDao.kt
@@ -14,6 +14,9 @@ interface ItemDao {
     @Delete
     suspend fun deleteItem(item: Item)
 
+    @Update
+    suspend fun updateItem(item: Item)
+
     @Query("SELECT * FROM items WHERE id=:id")
     suspend fun getItemById(id: String): Item
 

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -1,0 +1,11 @@
+package org.feature.fox.coffee_counter.data.repository
+
+import org.feature.fox.coffee_counter.data.local.dao.ItemDao
+import org.feature.fox.coffee_counter.di.services.network.ApiService
+import javax.inject.Inject
+
+class ItemRepository @Inject constructor(
+    private val itemDao: ItemDao,
+    private val apiService: ApiService
+) {
+}

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -3,8 +3,11 @@ package org.feature.fox.coffee_counter.data.repository
 import androidx.lifecycle.LiveData
 import org.feature.fox.coffee_counter.data.local.dao.ItemDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
+import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
+import org.feature.fox.coffee_counter.data.models.response.ItemResponse
 import org.feature.fox.coffee_counter.di.services.network.ApiService
+import retrofit2.Response
 import javax.inject.Inject
 
 class ItemRepository @Inject constructor(
@@ -12,19 +15,20 @@ class ItemRepository @Inject constructor(
     private val apiService: ApiService
 ) : ItemRepositoryInt {
 
-    override suspend fun insertItem(item: Item) {
+    override suspend fun insertItemDb(item: Item) {
         itemDao.insertItem(item)
     }
 
-    override suspend fun deleteItem(item: Item) {
+    override suspend fun deleteItemDb(item: Item) {
         itemDao.deleteItem(item)
     }
 
-    override suspend fun updateItem(item: Item) {
+    override suspend fun updateItemDb(item: Item) {
         itemDao.updateItem(item)
     }
 
-    override suspend fun getItemById(id: String): Item {
+
+    override suspend fun getItemByIdDb(id: String): Item {
         return itemDao.getItemById(id)
     }
 
@@ -36,11 +40,30 @@ class ItemRepository @Inject constructor(
         return itemDao.observeTotalPrice()
     }
 
-    override suspend fun postItem(item: Item) {
-
+    override suspend fun postItem(itemBody: ItemBody): Response<String> {
+        return apiService.postItem(itemBody)
     }
 
-    override suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody) {
-        apiService.purchaseItem(itemId, purchaseBody)
+    override suspend fun getItems(): Response<List<ItemResponse>> {
+        return apiService.getItems()
+    }
+
+    override suspend fun getItemByID(id: String): Response<ItemResponse> {
+        return apiService.getItemById(id)
+    }
+
+    override suspend fun deleteItemById(id: String): Response<String> {
+        return apiService.deleteItem(id)
+    }
+
+    override suspend fun updateItem(id: String, itemBody: ItemBody): Response<String> {
+        return apiService.updateItem(id, itemBody)
+    }
+
+    override suspend fun purchaseItem(
+        itemId: String,
+        purchaseBody: PurchaseBody
+    ): Response<String> {
+        return apiService.purchaseItem(itemId, purchaseBody)
     }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -7,7 +7,7 @@ import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
 import org.feature.fox.coffee_counter.data.models.response.ItemResponse
 import org.feature.fox.coffee_counter.di.services.network.ApiService
-import retrofit2.Response
+import org.feature.fox.coffee_counter.util.Resource
 import javax.inject.Inject
 
 class ItemRepository @Inject constructor(
@@ -28,8 +28,8 @@ class ItemRepository @Inject constructor(
     }
 
 
-    override suspend fun getItemByIdDb(id: String): Item {
-        return itemDao.getItemById(id)
+    override suspend fun getItemByIdDb(itemId: String): Item {
+        return itemDao.getItemById(itemId)
     }
 
     override fun observeAllItems(): LiveData<List<Item>> {
@@ -40,30 +40,96 @@ class ItemRepository @Inject constructor(
         return itemDao.observeTotalPrice()
     }
 
-    override suspend fun postItem(itemBody: ItemBody): Response<String> {
-        return apiService.postItem(itemBody)
+    override suspend fun postItem(itemBody: ItemBody): Resource<String> {
+        return try {
+            val response = apiService.postItem(itemBody)
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside postItem method", null)
+            } else {
+                Resource.error("Unknown error occured inside postItem method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 
-    override suspend fun getItems(): Response<List<ItemResponse>> {
-        return apiService.getItems()
+    override suspend fun getItems(): Resource<List<ItemResponse>> {
+        return try {
+            val response = apiService.getItems()
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside getItems method", null)
+            } else {
+                Resource.error("Unknown error occured inside getItems method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 
-    override suspend fun getItemByID(id: String): Response<ItemResponse> {
-        return apiService.getItemById(id)
+    override suspend fun getItemById(itemId: String): Resource<ItemResponse> {
+        return try {
+            val response = apiService.getItemById(itemId)
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside getItemById method", null)
+            } else {
+                Resource.error("Unknown error occured inside getItemById method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 
-    override suspend fun deleteItemById(id: String): Response<String> {
-        return apiService.deleteItem(id)
+    override suspend fun deleteItemById(itemId: String): Resource<String> {
+        return try {
+            val response = apiService.deleteItem(itemId)
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside deleteItemById method", null)
+            } else {
+                Resource.error("Unknown error occured inside deleteItemById method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 
-    override suspend fun updateItem(id: String, itemBody: ItemBody): Response<String> {
-        return apiService.updateItem(id, itemBody)
+    override suspend fun updateItem(itemId: String, itemBody: ItemBody): Resource<String> {
+        return try {
+            val response = apiService.updateItem(itemId, itemBody)
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside updateItem method", null)
+            } else {
+                Resource.error("Unknown error occured inside updateItem method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 
     override suspend fun purchaseItem(
         itemId: String,
         purchaseBody: PurchaseBody
-    ): Response<String> {
-        return apiService.purchaseItem(itemId, purchaseBody)
+    ): Resource<String> {
+        return try {
+            val response = apiService.purchaseItem(itemId, purchaseBody)
+            if (response.isSuccessful) {
+                response.body()?.let {
+                    return@let Resource.success(it)
+                } ?: Resource.error("Unknown error occured inside purchaseItem method", null)
+            } else {
+                Resource.error("Unknown error occured inside purchaseItem method", null)
+            }
+        } catch (e: Exception) {
+            Resource.error("Could not reach the server.", null)
+        }
     }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -1,11 +1,46 @@
 package org.feature.fox.coffee_counter.data.repository
 
+import androidx.lifecycle.LiveData
 import org.feature.fox.coffee_counter.data.local.dao.ItemDao
+import org.feature.fox.coffee_counter.data.local.database.tables.Item
+import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
 import org.feature.fox.coffee_counter.di.services.network.ApiService
 import javax.inject.Inject
 
 class ItemRepository @Inject constructor(
     private val itemDao: ItemDao,
     private val apiService: ApiService
-) {
+) : ItemRepositoryInt {
+
+    override suspend fun insertItem(item: Item) {
+        itemDao.insertItem(item)
+    }
+
+    override suspend fun deleteItem(item: Item) {
+        itemDao.deleteItem(item)
+    }
+
+    override suspend fun updateItem(item: Item) {
+        itemDao.updateItem(item)
+    }
+
+    override suspend fun getItemById(id: String): Item {
+        return itemDao.getItemById(id)
+    }
+
+    override fun observeAllItems(): LiveData<List<Item>> {
+        return itemDao.observeAllItems()
+    }
+
+    override fun observeTotalPrice(): LiveData<Double> {
+        return itemDao.observeTotalPrice()
+    }
+
+    override suspend fun postItem(item: Item) {
+
+    }
+
+    override suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody) {
+        apiService.purchaseItem(itemId, purchaseBody)
+    }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
@@ -1,0 +1,20 @@
+package org.feature.fox.coffee_counter.data.repository
+
+import androidx.lifecycle.LiveData
+import org.feature.fox.coffee_counter.data.local.database.tables.Item
+
+interface ItemRepositoryInt {
+
+    suspend fun insertItem(item: Item)
+
+    suspend fun deleteItem(item: Item)
+
+    suspend fun updateItem(item: Item)
+
+    suspend fun getItemById(id: String): Item
+
+
+    fun observeAllItems(): LiveData<List<Item>>
+
+    fun observeTotalPrice(): LiveData<Double>
+}

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
@@ -2,6 +2,7 @@ package org.feature.fox.coffee_counter.data.repository
 
 import androidx.lifecycle.LiveData
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
+import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
 
 interface ItemRepositoryInt {
 
@@ -13,8 +14,11 @@ interface ItemRepositoryInt {
 
     suspend fun getItemById(id: String): Item
 
-
     fun observeAllItems(): LiveData<List<Item>>
 
     fun observeTotalPrice(): LiveData<Double>
+
+    suspend fun postItem(item: Item)
+
+    suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody)
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
@@ -2,23 +2,34 @@ package org.feature.fox.coffee_counter.data.repository
 
 import androidx.lifecycle.LiveData
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
+import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
+import org.feature.fox.coffee_counter.data.models.response.ItemResponse
+import retrofit2.Response
 
 interface ItemRepositoryInt {
 
-    suspend fun insertItem(item: Item)
+    suspend fun insertItemDb(item: Item)
 
-    suspend fun deleteItem(item: Item)
+    suspend fun deleteItemDb(item: Item)
 
-    suspend fun updateItem(item: Item)
+    suspend fun updateItemDb(item: Item)
 
-    suspend fun getItemById(id: String): Item
+    suspend fun getItemByIdDb(id: String): Item
 
     fun observeAllItems(): LiveData<List<Item>>
 
     fun observeTotalPrice(): LiveData<Double>
 
-    suspend fun postItem(item: Item)
+    suspend fun postItem(itemBody: ItemBody): Response<String>
 
-    suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody)
+    suspend fun getItems(): Response<List<ItemResponse>>
+
+    suspend fun getItemByID(id: String): Response<ItemResponse>
+
+    suspend fun updateItem(id: String, itemBody: ItemBody): Response<String>
+
+    suspend fun deleteItemById(id: String): Response<String>
+
+    suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody): Response<String>
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepositoryInt.kt
@@ -5,7 +5,7 @@ import org.feature.fox.coffee_counter.data.local.database.tables.Item
 import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
 import org.feature.fox.coffee_counter.data.models.response.ItemResponse
-import retrofit2.Response
+import org.feature.fox.coffee_counter.util.Resource
 
 interface ItemRepositoryInt {
 
@@ -15,21 +15,21 @@ interface ItemRepositoryInt {
 
     suspend fun updateItemDb(item: Item)
 
-    suspend fun getItemByIdDb(id: String): Item
+    suspend fun getItemByIdDb(itemId: String): Item
 
     fun observeAllItems(): LiveData<List<Item>>
 
     fun observeTotalPrice(): LiveData<Double>
 
-    suspend fun postItem(itemBody: ItemBody): Response<String>
+    suspend fun postItem(itemBody: ItemBody): Resource<String>
 
-    suspend fun getItems(): Response<List<ItemResponse>>
+    suspend fun getItems(): Resource<List<ItemResponse>>
 
-    suspend fun getItemByID(id: String): Response<ItemResponse>
+    suspend fun getItemById(itemId: String): Resource<ItemResponse>
 
-    suspend fun updateItem(id: String, itemBody: ItemBody): Response<String>
+    suspend fun updateItem(itemId: String, itemBody: ItemBody): Resource<String>
 
-    suspend fun deleteItemById(id: String): Response<String>
+    suspend fun deleteItemById(itemId: String): Resource<String>
 
-    suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody): Response<String>
+    suspend fun purchaseItem(itemId: String, purchaseBody: PurchaseBody): Resource<String>
 }


### PR DESCRIPTION
Implemented Item Repository mentioned in #30. 

- Basic db operations like `insert`, `delete`, `update` and `getById` were implemented using the `itemDao` implemented in #20  
- Methods for getting observable live data like the a list off all items or the totalPrice of all items were implemented
- Implemented methods for using the `ApiService`, whereas the return type has been changed to `Resource<T>` that was added with #29 
- Added `ItemRepositoryInt` interface for creating a fake repository for testing purposes (should be used for ViewModel tests, see [here](https://www.youtube.com/watch?v=B-dJTFeOAqw&list=PLQkwcJG4YTCSYJ13G4kVIJ10X5zisB2Lq&index=10) or [here](https://www.youtube.com/watch?v=JsktEQvoHEs&list=PLQkwcJG4YTCSYJ13G4kVIJ10X5zisB2Lq&index=10)