### PR TITLE
Bearer Token

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -6,13 +6,14 @@ import org.feature.fox.coffee_counter.data.local.database.tables.Item
 import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody
 import org.feature.fox.coffee_counter.data.models.response.ItemResponse
+import org.feature.fox.coffee_counter.di.module.ApiModule
 import org.feature.fox.coffee_counter.di.services.network.ApiService
 import org.feature.fox.coffee_counter.util.Resource
 import javax.inject.Inject
 
 class ItemRepository @Inject constructor(
     private val itemDao: ItemDao,
-    private val apiService: ApiService
+    private val apiService: ApiService,
 ) : ItemRepositoryInt {
 
     override suspend fun insertItemDb(item: Item) {
@@ -26,7 +27,6 @@ class ItemRepository @Inject constructor(
     override suspend fun updateItemDb(item: Item) {
         itemDao.updateItem(item)
     }
-
 
     override suspend fun getItemByIdDb(itemId: String): Item {
         return itemDao.getItemById(itemId)
@@ -42,7 +42,8 @@ class ItemRepository @Inject constructor(
 
     override suspend fun postItem(itemBody: ItemBody): Resource<String> {
         return try {
-            val response = apiService.postItem(itemBody)
+            val response =
+                apiService.postItem(ApiModule.providesBearerInterceptor().bearerToken, itemBody)
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)
@@ -87,7 +88,8 @@ class ItemRepository @Inject constructor(
 
     override suspend fun deleteItemById(itemId: String): Resource<String> {
         return try {
-            val response = apiService.deleteItem(itemId)
+            val response =
+                apiService.deleteItem(ApiModule.providesBearerInterceptor().bearerToken, itemId)
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)
@@ -102,7 +104,9 @@ class ItemRepository @Inject constructor(
 
     override suspend fun updateItem(itemId: String, itemBody: ItemBody): Resource<String> {
         return try {
-            val response = apiService.updateItem(itemId, itemBody)
+            val response = apiService.updateItem(ApiModule.providesBearerInterceptor().bearerToken,
+                itemId,
+                itemBody)
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)
@@ -117,10 +121,13 @@ class ItemRepository @Inject constructor(
 
     override suspend fun purchaseItem(
         itemId: String,
-        purchaseBody: PurchaseBody
+        purchaseBody: PurchaseBody,
     ): Resource<String> {
         return try {
-            val response = apiService.purchaseItem(itemId, purchaseBody)
+            val response =
+                apiService.purchaseItem(ApiModule.providesBearerInterceptor().bearerToken,
+                    itemId,
+                    purchaseBody)
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/module/ApiModule.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/module/ApiModule.kt
@@ -8,6 +8,7 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.feature.fox.coffee_counter.di.services.network.ApiService
+import org.feature.fox.coffee_counter.di.services.network.BearerInterceptor
 import org.feature.fox.coffee_counter.util.Constants
 import retrofit2.Converter
 import retrofit2.Retrofit
@@ -29,13 +30,20 @@ object ApiModule {
         return HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
     }
 
+    @Provides
+    fun providesBearerInterceptor(): BearerInterceptor {
+        return BearerInterceptor()
+    }
+
     @Singleton
     @Provides
     fun provideOkHttpClient(
-        loggingInterceptor: Interceptor
+        loggingInterceptor: Interceptor,
+        bearerInterceptor: BearerInterceptor,
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
+            .addInterceptor(bearerInterceptor)
             .callTimeout(10, TimeUnit.SECONDS)
             .connectTimeout(10, TimeUnit.SECONDS)
             .readTimeout(10, TimeUnit.SECONDS)
@@ -48,7 +56,7 @@ object ApiModule {
     fun provideRetrofit(
         baseUrl: String,
         convFact: Converter.Factory,
-        okHttpClient: OkHttpClient
+        okHttpClient: OkHttpClient,
     ): Retrofit {
         return Retrofit.Builder()
             .addConverterFactory(convFact)

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/ApiService.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/ApiService.kt
@@ -17,6 +17,9 @@ interface ApiService {
     @POST(LOGIN_ENDPOINT)
     suspend fun postLogin(@Body loginBody: LoginBody): Response<LoginResponse>
 
+    @POST(USERS_ENDPOINT)
+    suspend fun signUp(@Body userBody: UserBody): Response<String>
+
     @GET(ITEMS_ENDPOINT)
     suspend fun getItems(): Response<List<ItemResponse>>
 
@@ -27,38 +30,73 @@ interface ApiService {
     suspend fun getUsers(): Response<List<UserResponse>>
 
     @GET("$USERS_ENDPOINT/{id}")
-    suspend fun getUserById(@Path("id") id: String): Response<UserIdResponse>
+    suspend fun getUserById(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+    ): Response<UserIdResponse>
 
     @PUT("$USERS_ENDPOINT/{id}")
-    suspend fun updateUser(@Path("id") id: String, @Body userBody: UserBody): Response<String>
-
-    @POST(USERS_ENDPOINT)
-    suspend fun signUp(@Body userBody: UserBody): Response<String>
+    suspend fun updateUser(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+        @Body userBody: UserBody,
+    ): Response<String>
 
     @DELETE("$USERS_ENDPOINT/{id}")
-    suspend fun deleteUser(@Path("id") id: String): Response<String>
+    suspend fun deleteUser(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+    ): Response<String>
 
     @GET("$USERS_ENDPOINT/{id}/transactions")
-    suspend fun getTransactions(@Path("id") id: String): Response<List<TransactionResponse>>
+    suspend fun getTransactions(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+    ): Response<List<TransactionResponse>>
 
     @POST("$USERS_ENDPOINT/{id}/purchases")
-    suspend fun purchaseItem(@Path("id") id: String, @Body purchaseBody: PurchaseBody): Response<String>
+    suspend fun purchaseItem(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+        @Body purchaseBody: PurchaseBody,
+    ): Response<String>
 
     @POST("$USERS_ENDPOINT/admin")
-    suspend fun adminSignUp(@Body userBody: UserBody): Response<String>
+    suspend fun adminSignUp(
+        @Header("Authorization") bearer: String,
+        @Body userBody: UserBody,
+    ): Response<String>
 
     @PUT("$USERS_ENDPOINT/admin/{id}")
-    suspend fun updateAdmin(@Path("id") id: String, @Body userBody: UserBody): Response<String>
+    suspend fun updateAdmin(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+        @Body userBody: UserBody,
+    ): Response<String>
 
     @POST("$USERS_ENDPOINT/{id}/funding")
-    suspend fun addFunding(@Path("id") id: String, @Body fundingBody: Double): Response<String>
+    suspend fun addFunding(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+        @Body fundingBody: Double,
+    ): Response<String>
 
     @POST(ITEMS_ENDPOINT)
-    suspend fun postItem(@Body itemBody: ItemBody): Response<String>
+    suspend fun postItem(
+        @Header("Authorization") bearer: String,
+        @Body itemBody: ItemBody,
+    ): Response<String>
 
     @PUT("$ITEMS_ENDPOINT/{id}")
-    suspend fun updateItem(@Path("id") id: String, @Body itemBody: ItemBody): Response<String>
+    suspend fun updateItem(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+        @Body itemBody: ItemBody,
+    ): Response<String>
 
     @DELETE("$ITEMS_ENDPOINT/{id}")
-    suspend fun deleteItem(@Path("id") id: String): Response<String>
+    suspend fun deleteItem(
+        @Header("Authorization") bearer: String,
+        @Path("id") id: String,
+    ): Response<String>
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/BearerInterceptor.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/BearerInterceptor.kt
@@ -1,0 +1,19 @@
+package org.feature.fox.coffee_counter.di.services.network
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import javax.inject.Singleton
+
+@Singleton
+class BearerInterceptor : Interceptor {
+
+    var bearerToken: String = ""
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request: Request = chain.request().newBuilder()
+            .addHeader("Authorization", "Bearer $bearerToken").build()
+
+        return chain.proceed(request)
+    }
+}

--- a/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
+++ b/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
@@ -129,7 +129,7 @@ class ApiServiceTest {
             .setBody(generateStringBody("Created new Item successfully."))
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.postItem(body)
+        val actualResponse = apiService.postItem(bearerToken, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -151,7 +151,7 @@ class ApiServiceTest {
             .setBody(generateStringBody("Updated Item successfully."))
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.updateItem(itemID, body)
+        val actualResponse = apiService.updateItem(bearerToken, itemID, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -172,7 +172,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.deleteItem(itemID)
+        val actualResponse = apiService.deleteItem(bearerToken, itemID)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -194,7 +194,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.addFunding(userId, body)
+        val actualResponse = apiService.addFunding(bearerToken, userId, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -215,7 +215,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.adminSignUp(body)
+        val actualResponse = apiService.adminSignUp(bearerToken, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -237,7 +237,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.updateAdmin(userId, body)
+        val actualResponse = apiService.updateAdmin(bearerToken, userId, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -283,7 +283,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.getUserById(userId)
+        val actualResponse = apiService.getUserById(bearerToken, userId)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -304,7 +304,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.getUserById(wrongUserId)
+        val actualResponse = apiService.getUserById(bearerToken, wrongUserId)
 
         assertThat(actualResponse.code()).isEqualTo(401)
         assertThat(actualResponse.body()).isNull()
@@ -325,7 +325,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.updateUser(userId, body)
+        val actualResponse = apiService.updateUser(bearerToken, userId, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -346,7 +346,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.deleteUser(userId)
+        val actualResponse = apiService.deleteUser(bearerToken, userId)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -367,7 +367,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.getTransactions(userId)
+        val actualResponse = apiService.getTransactions(bearerToken, userId)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)
@@ -389,7 +389,7 @@ class ApiServiceTest {
 
         mockWebServer.enqueue(response)
 
-        val actualResponse = apiService.purchaseItem(userId, body)
+        val actualResponse = apiService.purchaseItem(bearerToken, userId, body)
 
         assertThat(actualResponse).isNotNull()
         assertThat(actualResponse.code()).isEqualTo(200)

--- a/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
+++ b/app/src/test/java/org/feature/fox/coffee_counter/di/services/network/ApiServiceTest.kt
@@ -34,6 +34,7 @@ class ApiServiceTest {
     var instantTaskExecutorRule = InstantTaskExecutorRule()
     private var mockWebServer = MockWebServer()
     private lateinit var apiService: ApiService
+    private val bearerToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9Is"
 
     @Before
     fun setup() {
@@ -43,7 +44,8 @@ class ApiServiceTest {
                 mockWebServer.url("/").toString(),
                 ApiModule.provideConverterFactory(),
                 ApiModule.provideOkHttpClient(
-                    ApiModule.providesLoggingInterceptor()
+                    ApiModule.providesLoggingInterceptor(),
+                    ApiModule.providesBearerInterceptor()
                 )
             )
         )


### PR DESCRIPTION
This feature implements a BearerInterceptor for using a bearerToken inside the Request Headers. #38 mentioned a different approach, but i've researched a bit and an Interceptor seemed to be the most common solution.