### PR TITLE
Refactor: Move dao to database package

### DIFF
--- a/app/src/androidTest/java/org/feature/fox/coffee_counter/data/local/dao/ItemDaoTest.kt
+++ b/app/src/androidTest/java/org/feature/fox/coffee_counter/data/local/dao/ItemDaoTest.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.feature.fox.coffee_counter.data.local.ItemDatabase
+import org.feature.fox.coffee_counter.data.local.database.dao.ItemDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
 import org.feature.fox.coffee_counter.getOrAwaitValue
 import org.junit.After

--- a/app/src/androidTest/java/org/feature/fox/coffee_counter/data/local/dao/UserDaoTest.kt
+++ b/app/src/androidTest/java/org/feature/fox/coffee_counter/data/local/dao/UserDaoTest.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.feature.fox.coffee_counter.data.local.UserDatabase
+import org.feature.fox.coffee_counter.data.local.database.dao.UserDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Funding
 import org.feature.fox.coffee_counter.data.local.database.tables.Purchase
 import org.feature.fox.coffee_counter.data.local.database.tables.User

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/local/ItemDatabase.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/local/ItemDatabase.kt
@@ -2,7 +2,7 @@ package org.feature.fox.coffee_counter.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import org.feature.fox.coffee_counter.data.local.dao.ItemDao
+import org.feature.fox.coffee_counter.data.local.database.dao.ItemDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
 
 @Database(

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/local/UserDatabase.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/local/UserDatabase.kt
@@ -2,7 +2,7 @@ package org.feature.fox.coffee_counter.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import org.feature.fox.coffee_counter.data.local.dao.UserDao
+import org.feature.fox.coffee_counter.data.local.database.dao.UserDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Funding
 import org.feature.fox.coffee_counter.data.local.database.tables.Purchase
 import org.feature.fox.coffee_counter.data.local.database.tables.User

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/local/database/dao/ItemDao.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/local/database/dao/ItemDao.kt
@@ -1,4 +1,4 @@
-package org.feature.fox.coffee_counter.data.local.dao
+package org.feature.fox.coffee_counter.data.local.database.dao
 
 import androidx.lifecycle.LiveData
 import androidx.room.*

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/local/database/dao/UserDao.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/local/database/dao/UserDao.kt
@@ -1,4 +1,4 @@
-package org.feature.fox.coffee_counter.data.local.dao
+package org.feature.fox.coffee_counter.data.local.database.dao
 
 import androidx.lifecycle.LiveData
 import androidx.room.*

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/ItemRepository.kt
@@ -1,7 +1,7 @@
 package org.feature.fox.coffee_counter.data.repository
 
 import androidx.lifecycle.LiveData
-import org.feature.fox.coffee_counter.data.local.dao.ItemDao
+import org.feature.fox.coffee_counter.data.local.database.dao.ItemDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
 import org.feature.fox.coffee_counter.data.models.body.ItemBody
 import org.feature.fox.coffee_counter.data.models.body.PurchaseBody

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/UserRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package org.feature.fox.coffee_counter.data.repository
 
 import androidx.lifecycle.LiveData
-import org.feature.fox.coffee_counter.data.local.dao.UserDao
+import org.feature.fox.coffee_counter.data.local.database.dao.UserDao
 import org.feature.fox.coffee_counter.data.local.database.tables.Funding
 import org.feature.fox.coffee_counter.data.local.database.tables.Purchase
 import org.feature.fox.coffee_counter.data.local.database.tables.User


### PR DESCRIPTION
# Context
We received feedback that it might be a better structure moving our dao-package.
I've researched a bit and it seems to be better moving it to the database package.