### PR TITLE
Add PreferenceManager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,8 @@ android {
         buildConfigField "String", "ITEMS_ENDPOINT", '"/items"'
         buildConfigField "String", "LOGIN_ENDPOINT", '"/login"'
         buildConfigField "String", "DATE_PATTERN", '"dd.MM.yy"'
+        buildConfigField "String", "USER_ID", '"USER_ID"'
+        buildConfigField "String", "USER_PASSWORD", '"USER_PASSWORD"'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -87,6 +89,7 @@ dependencies {
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
     implementation "androidx.activity:activity-compose:1.4.0"
+    implementation "androidx.preference:preference-ktx:1.2.0"
 
     // Navbar
     implementation "androidx.navigation:navigation-compose:2.5.0-rc01"

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/AppPreference.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/AppPreference.kt
@@ -1,0 +1,20 @@
+package org.feature.fox.coffee_counter.di.services
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppPreference @Inject constructor(@ApplicationContext context: Context) {
+    private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun getTag(name: String): String {
+        return preferences.getString(name, "") ?: return ""
+    }
+
+    fun setTag(name: String, content: String) {
+        preferences.edit().putString(name, content).apply()
+    }
+}

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -3,13 +3,14 @@ package org.feature.fox.coffee_counter.ui.authentication
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.feature.fox.coffee_counter.BuildConfig
 import org.feature.fox.coffee_counter.data.models.body.LoginBody
 import org.feature.fox.coffee_counter.data.repository.UserRepository
 import org.feature.fox.coffee_counter.di.module.ApiModule
+import org.feature.fox.coffee_counter.di.services.AppPreference
 import javax.inject.Inject
 
 interface IAuthenticationViewModel {
@@ -25,6 +26,7 @@ interface IAuthenticationViewModel {
 @HiltViewModel
 class AuthenticationViewModel @Inject constructor(
     private val userRepository: UserRepository,
+    private val preference: AppPreference,
 ) : ViewModel(), IAuthenticationViewModel {
     override var nameState = mutableStateOf(TextFieldValue())
     override var idState = mutableStateOf(TextFieldValue())
@@ -39,6 +41,9 @@ class AuthenticationViewModel @Inject constructor(
         if (response.data == null) {
             return
         }
+
+        preference.setTag(BuildConfig.USER_ID, idState.value.text)
+        preference.setTag(BuildConfig.USER_PASSWORD, passwordState.value.text)
 
         ApiModule.providesBearerInterceptor().expiration = response.data.expiration
         ApiModule.providesBearerInterceptor().bearerToken = response.data.token


### PR DESCRIPTION
# Context
The user-login data is now stored in a SharedPreference.
I've had to add a library, because `import android.preference.PreferenceManager` is deprecated.