### PR TITLE
Complete AuthViewModel-core

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/MainActivity.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import dagger.hilt.android.AndroidEntryPoint
-import org.feature.fox.coffee_counter.ui.profile.ProfileView
+import org.feature.fox.coffee_counter.ui.authentication.HomeView
 import org.feature.fox.coffee_counter.ui.theme.CoffeeCounterTheme
 
 @AndroidEntryPoint
@@ -13,7 +13,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             CoffeeCounterTheme {
-                ProfileView()
+                HomeView()
             }
         }
     }

--- a/app/src/main/java/org/feature/fox/coffee_counter/data/repository/UserRepository.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/data/repository/UserRepository.kt
@@ -74,9 +74,10 @@ class UserRepository @Inject constructor(
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)
-                } ?: Resource.error("Unknown error occurred inside updateItem method", null)
+                } ?: Resource.error("Unknown error occurred.", null)
             } else {
-                Resource.error("Unknown error occurred inside updateItem method", null)
+                val errorMessage = response.errorBody()?.string() ?: ""
+                Resource.error(errorMessage, null)
             }
         } catch (e: Exception) {
             Resource.error("Could not reach the server.", null)
@@ -134,9 +135,10 @@ class UserRepository @Inject constructor(
             if (response.isSuccessful) {
                 response.body()?.let {
                     return@let Resource.success(it)
-                } ?: Resource.error("Unknown error occurred inside updateItem method", null)
+                } ?: Resource.error("Unknown error occurred.", null)
             } else {
-                Resource.error("Unknown error occurred inside updateItem method", null)
+                val errorMessage = response.errorBody()?.string() ?: ""
+                Resource.error(errorMessage, null)
             }
         } catch (e: Exception) {
             Resource.error("Could not reach the server.", null)

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/ResourceProvider.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/ResourceProvider.kt
@@ -1,0 +1,16 @@
+package org.feature.fox.coffee_counter.di.services
+
+import android.content.Context
+import androidx.annotation.StringRes
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ResourcesProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun getString(@StringRes stringResId: Int): String {
+        return context.getString(stringResId)
+    }
+}

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationActivity.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationActivity.kt
@@ -16,8 +16,7 @@ class AuthenticationActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val login = intent?.extras?.getBoolean("login") ?: true
-
+        authenticationViewModel.loginState.value = intent?.extras?.getBoolean("login") ?: true
         authenticationViewModel.toastMessage.observe(this) { message ->
             Toast.makeText(this@AuthenticationActivity, message, Toast.LENGTH_SHORT).show()
         }
@@ -25,7 +24,6 @@ class AuthenticationActivity : ComponentActivity() {
         setContent {
             CoffeeCounterTheme {
                 AuthenticationView(
-                    login,
                     authenticationViewModel
                 )
             }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationActivity.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationActivity.kt
@@ -1,6 +1,7 @@
 package org.feature.fox.coffee_counter.ui.authentication
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -16,6 +17,10 @@ class AuthenticationActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val login = intent?.extras?.getBoolean("login") ?: true
+
+        authenticationViewModel.toastMessage.observe(this) { message ->
+            Toast.makeText(this@AuthenticationActivity, message, Toast.LENGTH_SHORT).show()
+        }
 
         setContent {
             CoffeeCounterTheme {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
@@ -68,7 +68,10 @@ fun LoginFragment(viewModel: IAuthenticationViewModel) {
     val context = LocalContext.current
 
     CommonTextField(state = viewModel.idState, label = stringResource(R.string.id_hint))
-    PasswordTextField(state = viewModel.passwordState, label = stringResource(R.string.password_hint))
+    PasswordTextField(
+        state = viewModel.passwordState,
+        label = stringResource(R.string.password_hint)
+    )
     RememberMeCheckbox()
     CustomButton(
         onClick = {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
@@ -85,6 +85,8 @@ fun LoginFragment(viewModel: IAuthenticationViewModel) {
 
 @Composable
 fun RegisterFragment(viewModel: IAuthenticationViewModel) {
+    val coroutineScope = rememberCoroutineScope()
+
     CommonTextField(state = viewModel.nameState, label = stringResource(R.string.name_hint))
     CommonTextField(state = viewModel.idState, label = stringResource(R.string.optional_id_hint))
     PasswordTextField(
@@ -96,6 +98,11 @@ fun RegisterFragment(viewModel: IAuthenticationViewModel) {
         label = stringResource(R.string.re_enter_password_hint)
     )
     CustomButton(
+        onClick = {
+            coroutineScope.launch {
+                viewModel.register()
+            }
+        },
         text = stringResource(R.string.sign_up)
     )
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -18,8 +21,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -29,24 +30,15 @@ import org.feature.fox.coffee_counter.ui.common.CommonTextField
 import org.feature.fox.coffee_counter.ui.common.CustomButton
 import org.feature.fox.coffee_counter.ui.common.PasswordTextField
 
-class LoginStateProvider : PreviewParameterProvider<Boolean> {
-    override val values: Sequence<Boolean> = sequenceOf(
-        true,
-        false,
-    )
-}
-
 @Preview(showSystemUi = true)
 @Composable
 fun AuthenticationViewPreview(
-    @PreviewParameter(LoginStateProvider::class) login: Boolean,
 ) {
-    AuthenticationView(login, AuthenticationViewModelPreview())
+    AuthenticationView(AuthenticationViewModelPreview())
 }
 
 @Composable
 fun AuthenticationView(
-    login: Boolean,
     viewModel: IAuthenticationViewModel,
 ) {
     Column(
@@ -55,9 +47,8 @@ fun AuthenticationView(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        val loginState = remember { mutableStateOf(login) }
-        LoginSignupHeader(loginState)
-        if (loginState.value) LoginFragment(viewModel) else RegisterFragment(viewModel)
+        LoginSignupHeader(viewModel)
+        if (viewModel.loginState.value) LoginFragment(viewModel) else RegisterFragment(viewModel)
     }
 }
 
@@ -111,7 +102,7 @@ fun RegisterFragment(viewModel: IAuthenticationViewModel) {
 }
 
 @Composable
-fun LoginSignupHeader(loginState: MutableState<Boolean>) {
+fun LoginSignupHeader(viewModel: IAuthenticationViewModel) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceAround
@@ -121,16 +112,16 @@ fun LoginSignupHeader(loginState: MutableState<Boolean>) {
             offset = Offset(8f, 8f),
             blurRadius = 8f
         )
-        if (loginState.value) {
+        if (viewModel.loginState.value) {
             HeaderButton(stringResource(R.string.login), dropShadow)
             HeaderButton(
                 text = stringResource(R.string.sign_up),
-                onClick = { loginState.value = false }
+                onClick = { viewModel.loginState.value = false }
             )
         } else {
             HeaderButton(
                 text = stringResource(R.string.login),
-                onClick = { loginState.value = true }
+                onClick = { viewModel.loginState.value = true }
             )
             HeaderButton(stringResource(R.string.sign_up), dropShadow)
         }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationView.kt
@@ -68,7 +68,7 @@ fun LoginFragment(viewModel: IAuthenticationViewModel) {
     val context = LocalContext.current
 
     CommonTextField(state = viewModel.idState, label = stringResource(R.string.id_hint))
-    PasswordTextField(state = viewModel.idState, label = stringResource(R.string.password_hint))
+    PasswordTextField(state = viewModel.passwordState, label = stringResource(R.string.password_hint))
     RememberMeCheckbox()
     CustomButton(
         onClick = {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -15,10 +15,10 @@ import org.feature.fox.coffee_counter.di.services.AppPreference
 import javax.inject.Inject
 
 interface IAuthenticationViewModel {
-    var nameState: MutableState<TextFieldValue>
-    var idState: MutableState<TextFieldValue>
-    var passwordState: MutableState<TextFieldValue>
-    var reEnteredPasswordState: MutableState<TextFieldValue>
+    val nameState: MutableState<TextFieldValue>
+    val idState: MutableState<TextFieldValue>
+    val passwordState: MutableState<TextFieldValue>
+    val reEnteredPasswordState: MutableState<TextFieldValue>
     val showCoreActivity: MutableLiveData<Boolean>
 
     suspend fun login()
@@ -30,10 +30,10 @@ class AuthenticationViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val preference: AppPreference,
 ) : ViewModel(), IAuthenticationViewModel {
-    override var nameState = mutableStateOf(TextFieldValue())
-    override var idState = mutableStateOf(TextFieldValue())
-    override var passwordState = mutableStateOf(TextFieldValue())
-    override var reEnteredPasswordState = mutableStateOf(TextFieldValue())
+    override val nameState = mutableStateOf(TextFieldValue())
+    override val idState = mutableStateOf(TextFieldValue())
+    override val passwordState = mutableStateOf(TextFieldValue())
+    override val reEnteredPasswordState = mutableStateOf(TextFieldValue())
     override val showCoreActivity = MutableLiveData<Boolean>()
 
     override suspend fun login() {
@@ -79,10 +79,10 @@ class AuthenticationViewModel @Inject constructor(
 }
 
 class AuthenticationViewModelPreview : IAuthenticationViewModel {
-    override var nameState = mutableStateOf(TextFieldValue("Peter"))
-    override var idState = mutableStateOf(TextFieldValue("4242"))
-    override var passwordState = mutableStateOf(TextFieldValue("1234"))
-    override var reEnteredPasswordState = mutableStateOf(TextFieldValue("1234"))
+    override val nameState = mutableStateOf(TextFieldValue("Peter"))
+    override val idState = mutableStateOf(TextFieldValue("4242"))
+    override val passwordState = mutableStateOf(TextFieldValue("1234"))
+    override val reEnteredPasswordState = mutableStateOf(TextFieldValue("1234"))
     override val showCoreActivity = MutableLiveData<Boolean>()
 
     override suspend fun login() {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -23,6 +23,7 @@ interface IAuthenticationViewModel {
     val reEnteredPasswordState: MutableState<TextFieldValue>
     val showCoreActivity: MutableLiveData<Boolean>
     val toastMessage: MutableLiveData<String>
+    val loginState: MutableState<Boolean>
 
     suspend fun login()
     suspend fun register()
@@ -40,6 +41,7 @@ class AuthenticationViewModel @Inject constructor(
     override val reEnteredPasswordState = mutableStateOf(TextFieldValue())
     override val showCoreActivity = MutableLiveData<Boolean>()
     override val toastMessage = MutableLiveData<String>()
+    override val loginState = mutableStateOf(false)
 
     override suspend fun login() {
         val loginBody = LoginBody(idState.value.text, passwordState.value.text)
@@ -76,7 +78,13 @@ class AuthenticationViewModel @Inject constructor(
             return
         }
 
+        switchToLogin()
+    }
+
+    private fun switchToLogin() {
         resetValues()
+        loginState.value = true
+        toastMessage.value = resource.getString(R.string.created_account)
     }
 
     private fun resetValues() {
@@ -93,6 +101,7 @@ class AuthenticationViewModelPreview : IAuthenticationViewModel {
     override val reEnteredPasswordState = mutableStateOf(TextFieldValue("1234"))
     override val showCoreActivity = MutableLiveData<Boolean>()
     override val toastMessage = MutableLiveData<String>()
+    override val loginState = mutableStateOf(true)
 
     override suspend fun login() {
         TODO("Not yet implemented")

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -13,6 +13,7 @@ import org.feature.fox.coffee_counter.data.models.body.UserBody
 import org.feature.fox.coffee_counter.data.repository.UserRepository
 import org.feature.fox.coffee_counter.di.module.ApiModule
 import org.feature.fox.coffee_counter.di.services.AppPreference
+import org.feature.fox.coffee_counter.di.services.ResourcesProvider
 import javax.inject.Inject
 
 interface IAuthenticationViewModel {
@@ -31,6 +32,7 @@ interface IAuthenticationViewModel {
 class AuthenticationViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val preference: AppPreference,
+    private val resource: ResourcesProvider,
 ) : ViewModel(), IAuthenticationViewModel {
     override val nameState = mutableStateOf(TextFieldValue())
     override val idState = mutableStateOf(TextFieldValue())
@@ -44,7 +46,7 @@ class AuthenticationViewModel @Inject constructor(
         val response = userRepository.postLogin(loginBody)
 
         if (response.data == null) {
-            toastMessage.value = response.message ?: R.string.unknown_error.toString()
+            toastMessage.value = response.message ?: resource.getString(R.string.unknown_error)
             return
         }
 
@@ -58,6 +60,7 @@ class AuthenticationViewModel @Inject constructor(
 
     override suspend fun register() {
         if (passwordState.value.text != reEnteredPasswordState.value.text) {
+            toastMessage.value = resource.getString(R.string.match_password)
             return
         }
 
@@ -69,7 +72,7 @@ class AuthenticationViewModel @Inject constructor(
         val response = userRepository.signUp(registerBody)
 
         if (response.data == null) {
-            toastMessage.value = response.message ?: R.string.unknown_error.toString()
+            toastMessage.value = response.message ?: resource.getString(R.string.unknown_error)
             return
         }
 

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.feature.fox.coffee_counter.BuildConfig
 import org.feature.fox.coffee_counter.data.models.body.LoginBody
+import org.feature.fox.coffee_counter.data.models.body.UserBody
 import org.feature.fox.coffee_counter.data.repository.UserRepository
 import org.feature.fox.coffee_counter.di.module.ApiModule
 import org.feature.fox.coffee_counter.di.services.AppPreference
@@ -21,6 +22,7 @@ interface IAuthenticationViewModel {
     val showCoreActivity: MutableLiveData<Boolean>
 
     suspend fun login()
+    suspend fun register()
 }
 
 @HiltViewModel
@@ -49,6 +51,31 @@ class AuthenticationViewModel @Inject constructor(
         ApiModule.providesBearerInterceptor().bearerToken = response.data.token
         showCoreActivity.value = true
     }
+
+    override suspend fun register() {
+        if (passwordState.value.text != reEnteredPasswordState.value.text) {
+            return
+        }
+
+        val registerBody = UserBody(
+            idState.value.text,
+            nameState.value.text,
+            passwordState.value.text,
+        )
+        val response = userRepository.signUp(registerBody)
+
+        if (response.data == null) {
+            return
+        }
+
+        resetValues()
+    }
+
+    private fun resetValues() {
+        nameState.value = TextFieldValue()
+        passwordState.value = TextFieldValue()
+        reEnteredPasswordState.value = TextFieldValue()
+    }
 }
 
 class AuthenticationViewModelPreview : IAuthenticationViewModel {
@@ -59,6 +86,10 @@ class AuthenticationViewModelPreview : IAuthenticationViewModel {
     override val showCoreActivity = MutableLiveData<Boolean>()
 
     override suspend fun login() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun register() {
         TODO("Not yet implemented")
     }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.feature.fox.coffee_counter.BuildConfig
+import org.feature.fox.coffee_counter.R
 import org.feature.fox.coffee_counter.data.models.body.LoginBody
 import org.feature.fox.coffee_counter.data.models.body.UserBody
 import org.feature.fox.coffee_counter.data.repository.UserRepository
@@ -20,6 +21,7 @@ interface IAuthenticationViewModel {
     val passwordState: MutableState<TextFieldValue>
     val reEnteredPasswordState: MutableState<TextFieldValue>
     val showCoreActivity: MutableLiveData<Boolean>
+    val toastMessage: MutableLiveData<String>
 
     suspend fun login()
     suspend fun register()
@@ -35,12 +37,14 @@ class AuthenticationViewModel @Inject constructor(
     override val passwordState = mutableStateOf(TextFieldValue())
     override val reEnteredPasswordState = mutableStateOf(TextFieldValue())
     override val showCoreActivity = MutableLiveData<Boolean>()
+    override val toastMessage = MutableLiveData<String>()
 
     override suspend fun login() {
         val loginBody = LoginBody(idState.value.text, passwordState.value.text)
         val response = userRepository.postLogin(loginBody)
 
         if (response.data == null) {
+            toastMessage.value = response.message ?: R.string.unknown_error.toString()
             return
         }
 
@@ -65,6 +69,7 @@ class AuthenticationViewModel @Inject constructor(
         val response = userRepository.signUp(registerBody)
 
         if (response.data == null) {
+            toastMessage.value = response.message ?: R.string.unknown_error.toString()
             return
         }
 
@@ -84,6 +89,7 @@ class AuthenticationViewModelPreview : IAuthenticationViewModel {
     override val passwordState = mutableStateOf(TextFieldValue("1234"))
     override val reEnteredPasswordState = mutableStateOf(TextFieldValue("1234"))
     override val showCoreActivity = MutableLiveData<Boolean>()
+    override val toastMessage = MutableLiveData<String>()
 
     override suspend fun login() {
         TODO("Not yet implemented")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="profile_image_label">Profile Image</string>
     <string name="unknown_error">Unknown error</string>
     <string name="match_password">Passwords do not match</string>
+    <string name="created_account">Account created. Please login!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="profile_title">Profile</string>
     <string name="user_admin">admin</string>
     <string name="profile_image_label">Profile Image</string>
+    <string name="unknown_error">Unknown error</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="user_admin">admin</string>
     <string name="profile_image_label">Profile Image</string>
     <string name="unknown_error">Unknown error</string>
+    <string name="match_password">Passwords do not match</string>
 </resources>


### PR DESCRIPTION
# Context
I think the #56 should be complete for now after this PR.
The only thing that is missing is a test for the feature, but we should focus on completing the other ViewModels first.

* fixes ProfileView() on Start
* Added errorBody in UserRepository (has to be changed for every other too in later PRs)
* Added Toast in activity (+errorMessages)
* changed vars to val
* add a ResourceProvider