### PR TITLE
Refresh bearer

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/di/module/ApiModule.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/module/ApiModule.kt
@@ -7,7 +7,6 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.feature.fox.coffee_counter.BuildConfig
-import org.feature.fox.coffee_counter.di.services.AppPreference
 import org.feature.fox.coffee_counter.di.services.network.ApiService
 import org.feature.fox.coffee_counter.di.services.network.BearerInterceptor
 import retrofit2.Converter
@@ -29,13 +28,6 @@ object ApiModule {
     @Provides
     fun providesLoggingInterceptor(): HttpLoggingInterceptor {
         return HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
-    }
-
-    @Provides
-    fun providesBearerInterceptor(
-        preference: AppPreference,
-    ): BearerInterceptor {
-        return BearerInterceptor(preference)
     }
 
     @Singleton
@@ -85,14 +77,14 @@ object ApiModule {
     @Singleton
     @Provides
     fun provideApiService(
-        preference: AppPreference,
+        bearerInterceptor: BearerInterceptor,
         retrofit: Retrofit = provideRetrofit(
             BuildConfig.BASE_URL,
             providesScalarsConverterFactory(),
             provideConverterFactory(),
             provideOkHttpClient(
                 providesLoggingInterceptor(),
-                providesBearerInterceptor(preference)
+                bearerInterceptor,
             )
         ),
     ): ApiService {

--- a/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/BearerInterceptor.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/di/services/network/BearerInterceptor.kt
@@ -1,23 +1,57 @@
 package org.feature.fox.coffee_counter.di.services.network
 
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import org.feature.fox.coffee_counter.BuildConfig
+import org.feature.fox.coffee_counter.data.models.body.LoginBody
 import org.feature.fox.coffee_counter.di.services.AppPreference
+import java.net.HttpURLConnection
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
 class BearerInterceptor @Inject constructor(
     private val preference: AppPreference,
+    private val apiService: Provider<ApiService>,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        var response = chain.proceed(buildRequest(chain))
+        if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            synchronized(this) {
+                runBlocking {
+                    refreshBearer()
+                    response = chain.proceed(buildRequest(chain))
+                }
+            }
+        }
+
+        return response
+    }
+
+    private fun buildRequest(chain: Interceptor.Chain): Request {
         val bearerToken = preference.getTag(BuildConfig.BEARER_TOKEN)
-        val request: Request = chain.request().newBuilder()
+        return chain.request().newBuilder()
             .addHeader("Authorization", "Bearer $bearerToken")
             .build()
+    }
 
-        return chain.proceed(request)
+    private suspend fun refreshBearer() {
+        if (apiService.get() == null) {
+            return
+        }
+        val loginBody = LoginBody(
+            preference.getTag(BuildConfig.USER_ID),
+            preference.getTag(BuildConfig.USER_PASSWORD)
+        )
+
+        val response = apiService.get().postLogin(loginBody)
+
+        response.body()?.let {
+            preference.setTag(BuildConfig.BEARER_TOKEN, it.token)
+            preference.setTag(BuildConfig.EXPIRATION, it.expiration.toString())
+        }
     }
 }


### PR DESCRIPTION
# Context
Closes #34. This one was a bit trickier since i got into a cyclic dependency.
I resolved it by using `Provider<ApiService>` instead of `ApiService`. The alternatives were using `Lazy<T>`, but that didn't seem to work or to create a new Wrapper for the ApiService. This one would just generate overhead in my opinion.
Otherwise there is a synchronized + runBlocking in the `intercept()`-function, because it can not be `suspend`.

To test this you can either write a bit of own logic to force a `HTTP_UNAUTHORIZED` or login -> wait 5min. (expiration-duration of bearer) -> try updating user. Then you should see the following in the log (or similiar):
```kotlin
--> PUT /users // not working therefore:
--> POST /login
<-- response /login // updates bearer
--> PUT /users
<-- response /users
```