### PR TITLE
Add more Validation to AuthenticationView

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -58,7 +58,7 @@ class AuthenticationViewModel @Inject constructor(
     }
 
     override suspend fun login() {
-        val loginBody = LoginBody(idState.value.text, passwordState.value.text)
+        val loginBody = LoginBody(idState.value.text.trim(), passwordState.value.text.trim())
         val response = userRepository.postLogin(loginBody)
 
         if (response.data == null) {
@@ -67,8 +67,8 @@ class AuthenticationViewModel @Inject constructor(
             return
         }
 
-        preference.setTag(BuildConfig.USER_ID, idState.value.text)
-        preference.setTag(BuildConfig.USER_PASSWORD, passwordState.value.text)
+        preference.setTag(BuildConfig.USER_ID, idState.value.text.trim())
+        preference.setTag(BuildConfig.USER_PASSWORD, passwordState.value.text.trim())
         preference.setTag(BuildConfig.EXPIRATION, response.data.expiration.toString())
         preference.setTag(BuildConfig.BEARER_TOKEN, response.data.token)
 
@@ -76,15 +76,15 @@ class AuthenticationViewModel @Inject constructor(
     }
 
     override suspend fun register() {
-        if (passwordState.value.text != reEnteredPasswordState.value.text) {
+        if (passwordState.value.text.trim() != reEnteredPasswordState.value.text.trim()) {
             toastChannel.send(UIText.StringResource(R.string.match_password))
             return
         }
 
         val registerBody = UserBody(
-            idState.value.text.ifEmpty { null },
-            nameState.value.text,
-            passwordState.value.text,
+            idState.value.text.trim().ifEmpty { java.util.UUID.randomUUID().toString() },
+            nameState.value.text.trim(),
+            passwordState.value.text.trim(),
         )
         val response = userRepository.signUp(registerBody)
 
@@ -97,11 +97,11 @@ class AuthenticationViewModel @Inject constructor(
         idState.value = TextFieldValue(response.data)
         userRepository.insertUser(
             User(
-                id = idState.value.text,
-                name = nameState.value.text,
+                id = idState.value.text.trim(),
+                name = nameState.value.text.trim(),
                 false,
                 password = BCrypt.withDefaults()
-                    .hashToString(12, passwordState.value.text.toCharArray())
+                    .hashToString(12, passwordState.value.text.trim().toCharArray())
             )
         )
         switchToLogin()

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/authentication/AuthenticationViewModel.kt
@@ -81,6 +81,16 @@ class AuthenticationViewModel @Inject constructor(
             return
         }
 
+        if (passwordState.value.text.trim().length < 8) {
+            toastChannel.send(UIText.StringResource(R.string.password_length))
+            return
+        }
+
+        if (nameState.value.text.trim().isBlank()) {
+            toastChannel.send(UIText.StringResource(R.string.empty_name))
+            return
+        }
+
         val registerBody = UserBody(
             idState.value.text.trim().ifEmpty { java.util.UUID.randomUUID().toString() },
             nameState.value.text.trim(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,6 @@
     <string name="updated_user">Successfully updated user</string>
     <string name="deleted_user">Successfully deleted user</string>
     <string name="server_not_reached">Could not reach server.</string>
+    <string name="password_length">Password must contain at least 8 characters</string>
+    <string name="empty_name">Name may not be empty</string>
 </resources>


### PR DESCRIPTION
# Context

Since some of the validation in AuthenticationView has already been implemented, I've only added some additional validations in the same manner:
- Show Toast Message if  `password.length < 8`
- Show Toast Message if `name.isBlank()` since this leads to invalid User Input error
- Removing Whitespaces at the beginning and end of each field at creation of `registerBody` and `loginBody`
- Generating random UUID if `ID` field is empty