### PR TITLE
fix: correct money amount in userList

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
@@ -157,7 +157,7 @@ fun MoneyEditRow(
         horizontalArrangement = Arrangement.End,
     ) {
         Text(
-            "${user.balance}€",
+            "${String.format("%.2f", user.balance)}€",
             fontWeight = FontWeight.Medium,
             color = Color.Gray,
             modifier = Modifier.width(60.dp)


### PR DESCRIPTION
# Context
I've fixed the annoying decimals inside the userlist.
There still has to be a fix implemented for huge numbers. They shouldn't force a linebreak.