### PR TITLE
FuzzySearch in UserList

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,9 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version"
 
+    // FuzzySearch
+    implementation 'me.xdrop:fuzzywuzzy:1.4.0'
+
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/common/SearchBar.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/common/SearchBar.kt
@@ -1,6 +1,5 @@
 package org.feature.fox.coffee_counter.ui.common
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -26,16 +25,18 @@ fun SearchBar(
     modifier: Modifier = Modifier,
     fraction: Float = 1.0f,
     state: MutableState<TextFieldValue>,
-    onClick: () -> Unit = {},
+    onValueChanged: () -> Unit = {},
 ) {
     TextField(
         value = state.value,
-        onValueChange = { state.value = it },
+        onValueChange = {
+            state.value = it
+            onValueChanged()
+        },
         trailingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
                 contentDescription = "Search",
-                modifier = Modifier.clickable(onClick = onClick),
             )
         },
         colors = TextFieldDefaults.textFieldColors(

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/common/SearchBar.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/common/SearchBar.kt
@@ -1,5 +1,6 @@
 package org.feature.fox.coffee_counter.ui.common
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -11,34 +12,36 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import org.feature.fox.coffee_counter.R
+import org.feature.fox.coffee_counter.ui.theme.CrayolaCopper
 
 @Composable
 fun SearchBar(
     modifier: Modifier = Modifier,
-    fraction: Float = 1.0f
+    fraction: Float = 1.0f,
+    state: MutableState<TextFieldValue>,
+    onClick: () -> Unit = {},
 ) {
-    val idState = remember { mutableStateOf(TextFieldValue()) }
     TextField(
-        value = idState.value,
-        onValueChange = { idState.value = it },
-        leadingIcon = {
+        value = state.value,
+        onValueChange = { state.value = it },
+        trailingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
-                contentDescription = null
+                contentDescription = "Search",
+                modifier = Modifier.clickable(onClick = onClick),
             )
         },
         colors = TextFieldDefaults.textFieldColors(
-            backgroundColor = Color.LightGray,
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent
+            backgroundColor = Color.White,
+            focusedIndicatorColor = CrayolaCopper,
+            unfocusedIndicatorColor = CrayolaCopper,
         ),
         placeholder = {
             Text(stringResource(R.string.search_hint))

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
@@ -82,7 +82,7 @@ fun ItemsView(
         floatingActionButtonPosition = FabPosition.Center,
         content = {
             Column {
-                SearchBar()
+//                SearchBar()
                 if (viewModel.isLoaded.value) ItemList(viewModel) else LoadingBox()
             }
         }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
@@ -43,7 +43,6 @@ import org.feature.fox.coffee_counter.R
 import org.feature.fox.coffee_counter.data.local.database.tables.Item
 import org.feature.fox.coffee_counter.ui.common.LoadingAnimation
 import org.feature.fox.coffee_counter.ui.common.MoneyAppBar
-import org.feature.fox.coffee_counter.ui.common.SearchBar
 import org.feature.fox.coffee_counter.ui.common.ToastMessage
 import org.feature.fox.coffee_counter.ui.theme.CrayolaCopper
 
@@ -82,12 +81,13 @@ fun ItemsView(
         floatingActionButtonPosition = FabPosition.Center,
         content = {
             Column {
-                SearchBar(
-                    state = viewModel.searchField,
-                    onValueChanged = {
-                        viewModel.search()
-                    },
-                )
+                // FIXME: add searchbar back in once the functionality is implemented
+//                SearchBar(
+//                    state = viewModel.searchField,
+//                    onValueChanged = {
+//                        viewModel.search()
+//                    },
+//                )
                 if (viewModel.isLoaded.value) ItemList(viewModel) else LoadingBox()
             }
         }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsView.kt
@@ -82,7 +82,12 @@ fun ItemsView(
         floatingActionButtonPosition = FabPosition.Center,
         content = {
             Column {
-//                SearchBar()
+                SearchBar(
+                    state = viewModel.searchField,
+                    onValueChanged = {
+                        viewModel.search()
+                    },
+                )
                 if (viewModel.isLoaded.value) ItemList(viewModel) else LoadingBox()
             }
         }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsViewModel.kt
@@ -153,9 +153,9 @@ class ItemsViewModel @Inject constructor(
             return false
         }
 
-        val cartItem: Item = itemsInShoppingCartState.first{it.id == item.id}
+        val cartItem: Item = itemsInShoppingCartState.first { it.id == item.id }
 
-        if(cartItem.amount >= item.amount){
+        if (cartItem.amount >= item.amount) {
             toastChannel.send(UIText.StringResource(R.string.not_available))
             return false
         }
@@ -173,28 +173,28 @@ class ItemsViewModel @Inject constructor(
 
     override suspend fun addStringItemToShoppingCart(item: String) {
         try {
-            val avItem: Item = availableItemsState.first{it.name == item}
+            val avItem: Item = availableItemsState.first { it.name == item }
 
             val success = addItemToShoppingCart(avItem)
-            if (success){
+            if (success) {
                 confirmBuyItemDialogVisible.value = true
             }
 
-        }catch(e: NoSuchElementException){
+        } catch (e: NoSuchElementException) {
             toastChannel.send(UIText.StringResource(R.string.not_exist))
             return
         }
     }
 
     override suspend fun getItemCartAmount(item: Item): Int {
-        val cartItem: Item = itemsInShoppingCartState.first{it.id == item.id}
+        val cartItem: Item = itemsInShoppingCartState.first { it.id == item.id }
         return cartItem.amount
     }
 
     override suspend fun removeItemFromShoppingCart(item: Item) {
-        val cartItem: Item = itemsInShoppingCartState.first{it.id == item.id}
+        val cartItem: Item = itemsInShoppingCartState.first { it.id == item.id }
 
-        if(cartItem.amount > 0){
+        if (cartItem.amount > 0) {
             cartItem.amount -= 1
             itemsInShoppingCartState.remove(cartItem)
             itemsInShoppingCartState.add(cartItem)
@@ -360,7 +360,8 @@ class ItemsViewModel @Inject constructor(
     }
 
     override fun search() {
-        TODO("Not yet implemented")
+        // TODO: needs to be implemented later,
+        //       but first this whole viewModel needs to be refactored
     }
 }
 

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/items/ItemsViewModel.kt
@@ -41,6 +41,7 @@ interface IItemsViewModel : IToast {
     val editItemDialogVisible: MutableState<Boolean>
     val confirmBuyItemDialogVisible: MutableState<Boolean>
     val balance: MutableState<Double>
+    val searchField: MutableState<TextFieldValue>
 
     suspend fun getItems()
     suspend fun addItemToShoppingCart(item: Item): Boolean
@@ -52,6 +53,7 @@ interface IItemsViewModel : IToast {
     suspend fun updateItem()
     suspend fun deleteItem()
     suspend fun getTotalBalance()
+    fun search()
 }
 
 @HiltViewModel
@@ -77,7 +79,7 @@ class ItemsViewModel @Inject constructor(
     override val editItemDialogVisible = mutableStateOf(false)
     override val confirmBuyItemDialogVisible = mutableStateOf(false)
     override val balance = mutableStateOf(0.0)
-
+    override val searchField = mutableStateOf(TextFieldValue())
 
     init {
         viewModelScope.launch {
@@ -356,6 +358,10 @@ class ItemsViewModel @Inject constructor(
         }
         balance.value = response.data.balance
     }
+
+    override fun search() {
+        TODO("Not yet implemented")
+    }
 }
 
 class ItemsViewModelPreview : IItemsViewModel {
@@ -376,6 +382,7 @@ class ItemsViewModelPreview : IItemsViewModel {
     override val editItemDialogVisible = mutableStateOf(false)
     override val confirmBuyItemDialogVisible = mutableStateOf(false)
     override val balance = mutableStateOf(50.0)
+    override val searchField = mutableStateOf(TextFieldValue())
 
     init {
         availableItemsState = mutableStateListOf(
@@ -426,6 +433,10 @@ class ItemsViewModelPreview : IItemsViewModel {
     }
 
     override suspend fun getTotalBalance() {
+        TODO("Not yet implemented")
+    }
+
+    override fun search() {
         TODO("Not yet implemented")
     }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
@@ -46,6 +46,7 @@ interface IUserListViewModel : IToast {
     val balance: MutableState<Double>
     val sendAmount: MutableState<TextFieldValue>
     val userIdPictureMap: MutableMap<String, Bitmap?>
+    val searchField: MutableState<TextFieldValue>
 
     suspend fun addFunding()
     suspend fun createUser()
@@ -76,6 +77,7 @@ class UserListViewModel @Inject constructor(
     override val balance = mutableStateOf(0.0)
     override val sendAmount = mutableStateOf(TextFieldValue())
     override val userIdPictureMap = mutableMapOf<String, Bitmap?>()
+    override val searchField = mutableStateOf(TextFieldValue())
 
     init {
         viewModelScope.launch {
@@ -276,6 +278,7 @@ class UserListViewModelPreview : IUserListViewModel {
     override val toast = toastChannel.receiveAsFlow()
     override val sendAmount = mutableStateOf(TextFieldValue())
     override val userIdPictureMap = mutableMapOf<String, Bitmap?>()
+    override val searchField = mutableStateOf(TextFieldValue())
 
     override suspend fun addFunding() {
         TODO("Not yet implemented")

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
@@ -52,6 +52,7 @@ interface IUserListViewModel : IToast {
     suspend fun createUser()
     suspend fun getTotalBalance()
     suspend fun sendMoney()
+    fun search()
 }
 
 @HiltViewModel
@@ -192,6 +193,10 @@ class UserListViewModel @Inject constructor(
         sendMoneyDialogVisible.value = false
     }
 
+    override fun search() {
+        TODO("Not yet implemented")
+    }
+
     private fun removeAndAddUser(user: UserIdResponse, amount: Double) {
         val index = userList.indexOf(currentUser.value)
         userList.remove(currentUser.value)
@@ -293,6 +298,10 @@ class UserListViewModelPreview : IUserListViewModel {
     }
 
     override suspend fun sendMoney() {
+        TODO("Not yet implemented")
+    }
+
+    override fun search() {
         TODO("Not yet implemented")
     }
 }

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UserListViewModel.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import me.xdrop.fuzzywuzzy.FuzzySearch
 import org.feature.fox.coffee_counter.BuildConfig
 import org.feature.fox.coffee_counter.R
 import org.feature.fox.coffee_counter.data.local.database.tables.Funding
@@ -28,7 +27,7 @@ import org.feature.fox.coffee_counter.data.repository.UserRepository
 import org.feature.fox.coffee_counter.di.services.AppPreference
 import org.feature.fox.coffee_counter.util.IToast
 import org.feature.fox.coffee_counter.util.UIText
-import java.util.*
+import org.feature.fox.coffee_counter.util.Utils
 import javax.inject.Inject
 
 interface IUserListViewModel : IToast {
@@ -198,16 +197,7 @@ class UserListViewModel @Inject constructor(
     }
 
     override fun search() {
-        filteredUserList.clear()
-        val searchResults = userList.filter {
-            FuzzySearch.partialRatio(it.name.lowercase(Locale.ROOT),
-                searchField.value.text.lowercase(Locale.ROOT)) > 80
-        }
-        if (searchResults.isNotEmpty()) {
-            filteredUserList.addAll(searchResults)
-            return
-        }
-        filteredUserList.addAll(userList)
+        Utils.fuzzySearch(filteredUserList, userList, searchField.value.text)
     }
 
     private fun removeAndAddUser(user: UserIdResponse, amount: Double) {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
@@ -86,7 +86,10 @@ fun UsersView(viewModel: IUserListViewModel) {
             {
                 SearchBar(
                     fraction = 0.8f,
-                    state = viewModel.searchField
+                    state = viewModel.searchField,
+                    onClick = {
+                        viewModel.search()
+                    }
                 )
                 Button(
                     shape = CircleShape,

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
@@ -84,7 +84,10 @@ fun UsersView(viewModel: IUserListViewModel) {
                 verticalAlignment = Alignment.CenterVertically,
             )
             {
-                SearchBar(fraction = 0.7f)
+                SearchBar(
+                    fraction = 0.8f,
+                    state = viewModel.searchField
+                )
                 Button(
                     shape = CircleShape,
                     onClick = {

--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/user/UsersView.kt
@@ -87,9 +87,9 @@ fun UsersView(viewModel: IUserListViewModel) {
                 SearchBar(
                     fraction = 0.8f,
                     state = viewModel.searchField,
-                    onClick = {
+                    onValueChanged = {
                         viewModel.search()
-                    }
+                    },
                 )
                 Button(
                     shape = CircleShape,
@@ -132,7 +132,7 @@ fun UserList(viewModel: IUserListViewModel) {
                 .height((IntrinsicSize.Min)),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            viewModel.userList.forEach { user ->
+            viewModel.filteredUserList.forEach { user ->
                 UserRow(viewModel, user)
             }
             Box(Modifier.height(50.dp))

--- a/app/src/main/java/org/feature/fox/coffee_counter/util/Utils.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/util/Utils.kt
@@ -1,0 +1,28 @@
+package org.feature.fox.coffee_counter.util
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import me.xdrop.fuzzywuzzy.FuzzySearch
+import org.feature.fox.coffee_counter.data.models.response.UserIdResponse
+import java.util.*
+
+class Utils {
+    companion object {
+        fun fuzzySearch(
+            filteredList: SnapshotStateList<UserIdResponse>,
+            list: SnapshotStateList<UserIdResponse>,
+            text: String,
+        ) {
+            filteredList.clear()
+            val searchResults = list.filter {
+                FuzzySearch.partialRatio(it.name.lowercase(Locale.ROOT),
+                    text.lowercase(Locale.ROOT)) > 80
+            }
+            if (text.isNotEmpty()) {
+                filteredList.addAll(searchResults)
+                return
+            }
+            filteredList.addAll(list)
+        }
+
+    }
+}


### PR DESCRIPTION
# Context
I've implemented a fuzzySearch (a search that doesn't need to match strings 1:1) for the userList.
Currently this feature isn't supported by the ItemsList, because it refreshes items way more often with `getItems()` in different methods. This needs to be refactored first.