### PR TITLE
fix: add init value if transations.size is zero

### DIFF
--- a/app/src/main/java/org/feature/fox/coffee_counter/ui/transaction/TransactionViewModel.kt
+++ b/app/src/main/java/org/feature/fox/coffee_counter/ui/transaction/TransactionViewModel.kt
@@ -189,8 +189,11 @@ class TransactionViewModel @Inject constructor(
     override suspend fun getBalanceOfUser() {
         balanceList.clear()
         // Assuming that they are already sorted by timestamp
-        //if(transactions == null) return
-        balanceList.add(Pair(transactions[0].timestamp, 0.0))
+        if (transactions == null) return
+        if (transactions.size == 0) {
+            balanceList.add(Pair(System.currentTimeMillis() / 1000, 0.0))
+        }
+        //balanceList.add(Pair(transactions[0].timestamp, 0.0))
         for (i in 1 until transactions.size) {
             balanceList.add(
                 Pair(


### PR DESCRIPTION
### Context
During presentation of code-week we encoutered a problem with a newly registered user that wants to login. The app crashes, throwing an `IndexOutOfBoundsException` since the transactions of this user are zero. Therefore, the balance calculation throwed this error and the app crashed.

I've implemented a fix which is adding an initial value to `balanceList` if `transactions.size == 0`